### PR TITLE
Adding crc_destuff module and refactoring bit stream processor for Fi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ xcelium.*
 *.gtkw
 *.diag
 *.vvp
+*.dump
 
 /testbench_xcelium/*.sv
 /testbench_icarus/*.sv

--- a/hdl/can_crc_destuff.sv
+++ b/hdl/can_crc_destuff.sv
@@ -1,0 +1,40 @@
+`include "timescale.sv"
+
+module can_crc_destuff(clk, rst, data, data_prev, enable, bit_cnt, fixed_stuff_bit_error, crc_17_o, crc_21_o);
+
+parameter Tp = 1;
+
+input clk, rst;
+input enable;
+input data;
+input [8:0] bit_cnt;
+input data_prev;
+
+output fixed_stuff_bit_error;
+output [16:0] crc_17_o;
+output [20:0] crc_21_o;
+
+reg [16:0] crc_17_r;
+reg [20:0] crc_21_r;
+wire stuff_bit_crc;      
+
+assign crc_17_o = crc_17_r;
+assign crc_21_o = crc_21_r;
+assign stuff_bit_crc =  (bit_cnt == 9'd0 | bit_cnt == 9'd5 | bit_cnt == 9'd10 | bit_cnt == 9'd15 | bit_cnt == 9'd20 | bit_cnt == 9'd25);
+assign fixed_stuff_bit_error = enable & stuff_bit_crc &  (data == data_prev);
+
+always @ (posedge clk or posedge rst)
+begin
+  if (rst) begin
+    crc_17_r <= #Tp 17'h0;
+    crc_21_r <= #Tp 21'h0;
+  end
+  else if(enable) begin
+    if ( ~ stuff_bit_crc ) begin
+        crc_17_r <=#Tp {crc_17_r[15:0], data};
+        crc_21_r <=#Tp {crc_21_r[19:0], data};
+    end
+  end
+end
+
+endmodule

--- a/hdl/can_dlc_decoder.sv
+++ b/hdl/can_dlc_decoder.sv
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////
 ////                                                              ////
-////  can_crc.v                                                   ////
+////  can_dlc_decoder.sv                                          ////
 ////                                                              ////
 ////  Utilizado para decodificar o Data Lenght Code em frames FD  ////
 //////////////////////////////////////////////////////////////////////
@@ -33,7 +33,7 @@ module can_dlc_decoder(
             4'b1100: data_len_out = 7'd24;
             4'b1101: data_len_out = 7'd32;
             4'b1110: data_len_out = 7'd48;
-            4'b1111: data_len_out = 7'd64;
+            default: data_len_out = 7'd64;
         endcase
     end else begin
         case (data_len_in)

--- a/testbench_base/can_testbench_tests.sv
+++ b/testbench_base/can_testbench_tests.sv
@@ -1942,8 +1942,8 @@ task manual_fd_frame_basic_rcv;
         send_fd_bits(8, 8'b10101001); // Byte de Dados 18
         send_fd_bits(8, 8'b10101001); // Byte de Dados 19
         send_fd_bits(8, 8'b10101001); // Byte de Dados 20
-        // send_bits(15+1, 16'b1111000101111011); (gera erro de valro incorreto de CRC para DLC  1)
-        send_fd_bits(22, 22'b1001000001110011101101); // CRC (with stuff bit)
+        // send_bits(15+1, 16'b1111000101111011); (gera erro de valro incorreto de CRC para DLC  1)// CRC (with stuff bit)
+        send_fd_bits(27, 27'b010010000010110101110011011); // CRC (with stuff bit)
         send_fd_bit(1);  // CRC DELIM
         send_bit(0);  // ACK
         send_bit(1);  // ACK DELIM

--- a/testbench_icarus/filelist.txt
+++ b/testbench_icarus/filelist.txt
@@ -3,6 +3,7 @@ can_top.sv
 can_acf.sv
 can_bsp.sv
 can_btl.sv
+can_crc_destuff.sv
 can_crc.sv
 can_defines.sv
 can_fifo.sv

--- a/testbench_xcelium/filelist.txt
+++ b/testbench_xcelium/filelist.txt
@@ -3,6 +3,7 @@ can_top.sv
 can_acf.sv
 can_bsp.sv
 can_btl.sv
+can_crc_destuff.sv
 can_crc.sv
 can_defines.sv
 can_fifo.sv


### PR DESCRIPTION
- Adicionando módulo para remover os stuff bits para CRC_17 e CRC_21
- Refatorando módulo de BSP para alterar a técnica de stuffing utilizada quando o frame recebido for FD
- Fixando ausencia de default case no módulo de DLC Decoder